### PR TITLE
Change go.mod package to use new major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Role Based Access Control (RBAC) Go package with database persistence
 # Install
 First get `authority`
 ```bash
-go get github.com/harranali/authority
+go get github.com/harranali/authority/v2
 ```
 Next get the database driver for `gorm` that you will be using 
 ```bash

--- a/authority_test.go
+++ b/authority_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/harranali/authority"
+	"github.com/harranali/authority/v2"
 	"github.com/joho/godotenv"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/harranali/authority
+module github.com/harranali/authority/v2
 
 go 1.16
 


### PR DESCRIPTION
Currently we can't just run `go get github.com/harranali/authority` and get the latest version.
We should update the package to include the new major version:
https://golang.cafe/blog/how-to-upgrade-to-a-major-version-in-go.html